### PR TITLE
Rework getWorkflowRunId() when run-name is provided

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -261,8 +261,8 @@ jobs:
         env:
           EXPECTED_LOG_MESSAGE: "### Env: ${{ matrix.environment }} ###"
         with:
-          expected: "true"
-          actual: ${{ fromJson(steps.named-run-workflow.outputs.workflow-logs).echo.*.message == env.EXPECTED_LOG_MESSAGE }}
+          expected: true
+          actual: ${{ contains(fromJson(steps.named-run-workflow.outputs.workflow-logs).echo.*.message, env.EXPECTED_LOG_MESSAGE) }}
 
   deploy:
     needs:

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -246,7 +246,7 @@ jobs:
           inputs: >-
             {
               "run-name": "${{ env.RUN_NAME }}",
-              "environment": "${{ matrix.environment }}",
+              "environment": "${{ matrix.environment }}"
             }
         continue-on-error: true
       - uses: nick-invision/assert-action@v1

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -183,6 +183,8 @@ jobs:
         token: ${{ secrets.PERSONAL_TOKEN }}
         wait-for-completion-interval: 10s
         wait-for-completion-timeout: 120s
+        display-workflow-run-url-interval: 10s
+        display-workflow-run-url-timeout: 120s
         workflow-logs: print
       continue-on-error: true
     - uses: nick-invision/assert-action@v1

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -92,6 +92,8 @@ jobs:
         token: ${{ secrets.PERSONAL_TOKEN }}
         wait-for-completion-interval: 10s
         wait-for-completion-timeout: 5m
+        display-workflow-run-url-interval: 10s
+        display-workflow-run-url-timeout: 5m
       continue-on-error: true
     - uses: nick-invision/assert-action@v1
       with:
@@ -121,7 +123,9 @@ jobs:
         workflow: failing.yml
         token: ${{ secrets.PERSONAL_TOKEN }}
         wait-for-completion-interval: 10s
-        wait-for-completion-timeout: 5m
+        wait-for-completion-timeout: 60s
+        display-workflow-run-url-interval: 10s
+        display-workflow-run-url-timeout: 60s
       continue-on-error: true
     - run: echo "worflow-conclusion=${{ steps.failing-workflow.outputs.workflow-conclusion }}"
     - uses: nick-invision/assert-action@v1
@@ -153,6 +157,8 @@ jobs:
         token: ${{ secrets.PERSONAL_TOKEN }}
         wait-for-completion-interval: 10s
         wait-for-completion-timeout: 30s
+        display-workflow-run-url-interval: 10s
+        display-workflow-run-url-timeout: 30s
       continue-on-error: true
     - uses: nick-invision/assert-action@v1
       with:
@@ -234,6 +240,8 @@ jobs:
           run-name: ${{ env.RUN_NAME }}
           wait-for-completion-interval: 10s
           wait-for-completion-timeout: 120s
+          display-workflow-run-url-interval: 10s
+          display-workflow-run-url-timeout: 120s
           workflow-logs: print
           inputs: >-
             {
@@ -261,6 +269,7 @@ jobs:
       - failing-test
       - timeout-test
       - print-workflow-logs-test
+      - parallel-runs-test
     runs-on: ubuntu-latest
     steps:
     - name: Check out repository

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -105,7 +105,7 @@ jobs:
   failing-test:
     needs: [build]
     runs-on: ubuntu-latest
-    name: "failing-test [trigger+wait|by workflow filename|shoud report failure]"
+    name: "failing-test [trigger+wait|by workflow filename|should report failure]"
     steps:
     - name: Check out repository
       uses: actions/checkout@v3
@@ -136,7 +136,7 @@ jobs:
   timeout-test:
     needs: [build]
     runs-on: ubuntu-latest
-    name: "timeout-test [trigger+wait|by workflow filename|shoud report timed_out]"
+    name: "timeout-test [trigger+wait|by workflow filename|should report timed_out]"
     steps:
     - name: Check out repository
       uses: actions/checkout@v3
@@ -166,7 +166,7 @@ jobs:
   print-workflow-logs-test:
     needs: [build]
     runs-on: ubuntu-latest
-    name: "print-workflow-logs-test [trigger+wait|by workflow filename|print logs|shoud report timed_out]"
+    name: "print-workflow-logs-test [trigger+wait|by workflow filename|print logs|should report timed_out]"
     steps:
     - name: Check out repository
       uses: actions/checkout@v3
@@ -198,10 +198,58 @@ jobs:
     # - name: Invoke external workflow using this action
     #   uses: ./
     #   with:
-    #     workflow: Deploy To Kubernetes           
+    #     workflow: Deploy To Kubernetes
     #     repo: benc-uk/dapr-store
     #     token: ${{ secrets.PERSONAL_TOKEN }}
-    #     ref: master 
+    #     ref: master
+
+  parallel-runs-test:
+    needs: [build]
+    runs-on: ubuntu-latest
+    name: "parallel-runs-test [trigger+wait|by workflow filename|should succeed]"
+    strategy:
+      fail-fast: false
+      matrix:
+        environment:
+          - trunk
+          - staging
+    env:
+      RUN_NAME: ${{ github.repository }}/actions/runs/${{ github.run_id }}/envs/${{ matrix.environment }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+      - name: Download dist
+        uses: actions/download-artifact@v3
+        with:
+          name: build
+          path: dist
+      - name: Invoke 'named-run' workflow for this environment and wait for result using this action
+        id: named-run-workflow
+        uses: ./
+        with:
+          workflow: named-run.yml
+          token: ${{ secrets.PERSONAL_TOKEN }}
+          run-name: ${{ env.RUN_NAME }}
+          wait-for-completion-interval: 10s
+          wait-for-completion-timeout: 120s
+          workflow-logs: print
+          inputs: >-
+            {
+              "run-name": "${{ env.RUN_NAME }}"
+            }
+        continue-on-error: true
+      - uses: nick-invision/assert-action@v1
+        with:
+          expected: success
+          actual: ${{ steps.named-run-workflow.outputs.workflow-conclusion }}
+      - uses: nick-invision/assert-action@v1
+        with:
+          expected: success
+          actual: ${{ steps.named-run-workflow.outcome }}
+      - uses: nick-invision/assert-action@v1
+        with:
+          expected: "Run name: ${{ env.RUN_NAME }}"
+          actual: ${{ steps.named-run-workflow.outcome }}
 
   deploy:
     needs:

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -242,10 +242,11 @@ jobs:
           wait-for-completion-timeout: 120s
           display-workflow-run-url-interval: 10s
           display-workflow-run-url-timeout: 120s
-          workflow-logs: print
+          workflow-logs: json-output
           inputs: >-
             {
-              "run-name": "${{ env.RUN_NAME }}"
+              "run-name": "${{ env.RUN_NAME }}",
+              "environment": "${{ matrix.environment }}",
             }
         continue-on-error: true
       - uses: nick-invision/assert-action@v1
@@ -257,9 +258,11 @@ jobs:
           expected: success
           actual: ${{ steps.named-run-workflow.outcome }}
       - uses: nick-invision/assert-action@v1
+        env:
+          EXPECTED_LOG_MESSAGE: "### Env: ${{ matrix.environment }} ###"
         with:
-          expected: "Run name: ${{ env.RUN_NAME }}"
-          actual: ${{ steps.named-run-workflow.outcome }}
+          expected: "true"
+          actual: ${{ fromJson(steps.named-run-workflow.outputs.workflow-logs).echo.*.message == env.EXPECTED_LOG_MESSAGE }}
 
   deploy:
     needs:

--- a/.github/workflows/echo-1.yaml
+++ b/.github/workflows/echo-1.yaml
@@ -1,8 +1,6 @@
 name: Message Echo 1
 
 on:
-  pull_request:
-    branches: [ master ]
   workflow_dispatch:
     inputs:
       message:

--- a/.github/workflows/echo-1.yaml
+++ b/.github/workflows/echo-1.yaml
@@ -1,6 +1,8 @@
 name: Message Echo 1
 
-on: 
+on:
+  pull_request:
+    branches: [ master ]
   workflow_dispatch:
     inputs:
       message:

--- a/.github/workflows/echo-2.yaml
+++ b/.github/workflows/echo-2.yaml
@@ -1,8 +1,6 @@
 name: Message Echo 2
 
 on:
-  pull_request:
-    branches: [ master ]
   workflow_dispatch:
     inputs:
       message:

--- a/.github/workflows/echo-2.yaml
+++ b/.github/workflows/echo-2.yaml
@@ -1,6 +1,8 @@
 name: Message Echo 2
 
-on: 
+on:
+  pull_request:
+    branches: [ master ]
   workflow_dispatch:
     inputs:
       message:

--- a/.github/workflows/failing.yml
+++ b/.github/workflows/failing.yml
@@ -1,8 +1,6 @@
 name: Failing
 
 on:
-  pull_request:
-    branches: [ master ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/failing.yml
+++ b/.github/workflows/failing.yml
@@ -1,6 +1,8 @@
 name: Failing
 
-on: 
+on:
+  pull_request:
+    branches: [ master ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/long-running.yml
+++ b/.github/workflows/long-running.yml
@@ -1,8 +1,6 @@
 name: Long running
 
 on:
-  pull_request:
-    branches: [ master ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/long-running.yml
+++ b/.github/workflows/long-running.yml
@@ -1,6 +1,8 @@
 name: Long running
 
-on: 
+on:
+  pull_request:
+    branches: [ master ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/named-run.yml
+++ b/.github/workflows/named-run.yml
@@ -8,6 +8,10 @@ on:
         description: 'The distinct run name used to retrieve the run ID. Defaults to the workflow name'
         type: string
         required: false
+      environment:
+        description: 'The environment name'
+        type: string
+        required: true
 
 jobs:
   echo:
@@ -17,4 +21,4 @@ jobs:
         run: sleep 10s
       - name: Echo message
         run: |
-          echo 'Run name: ${{ github.event.inputs.run-name || github.workflow }}'
+          echo '### Env: ${{ github.event.inputs.environment }} ###'

--- a/.github/workflows/named-run.yml
+++ b/.github/workflows/named-run.yml
@@ -2,8 +2,6 @@ name: Named run
 run-name: ${{ inputs.run-name }}
 
 on:
-  pull_request:
-    branches: [ master ]
   workflow_dispatch:
     inputs:
       run-name:

--- a/.github/workflows/named-run.yml
+++ b/.github/workflows/named-run.yml
@@ -2,6 +2,8 @@ name: Named run
 run-name: ${{ inputs.run-name }}
 
 on:
+  pull_request:
+    branches: [ master ]
   workflow_dispatch:
     inputs:
       run-name:

--- a/.github/workflows/named-run.yml
+++ b/.github/workflows/named-run.yml
@@ -1,0 +1,20 @@
+name: Named run
+run-name: ${{ inputs.run-name }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      run-name:
+        description: 'The distinct run name used to retrieve the run ID. Defaults to the workflow name'
+        type: string
+        required: false
+
+jobs:
+  echo:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sleep
+        run: sleep 10s
+      - name: Echo message
+        run: |
+          echo 'Run name: ${{ github.event.inputs.run-name || github.workflow }}'

--- a/.github/workflows/retrieve-logs.yml
+++ b/.github/workflows/retrieve-logs.yml
@@ -1,8 +1,6 @@
 name: Retrieve logs
 
 on:
-  pull_request:
-    branches: [ master ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/retrieve-logs.yml
+++ b/.github/workflows/retrieve-logs.yml
@@ -1,6 +1,8 @@
 name: Retrieve logs
 
-on: 
+on:
+  pull_request:
+    branches: [ master ]
   workflow_dispatch:
 
 jobs:
@@ -13,14 +15,14 @@ jobs:
           do
             echo "Hello $i"
             sleep 0.1
-          done    
-  
+          done
+
   timeout:
     runs-on: ubuntu-latest
     steps:
       - name: Sleep
         run: sleep 1200s
-  
+
   more-real-example:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/timeout.yml
+++ b/.github/workflows/timeout.yml
@@ -1,6 +1,8 @@
 name: Timeout
 
-on: 
+on:
+  pull_request:
+    branches: [ master ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/timeout.yml
+++ b/.github/workflows/timeout.yml
@@ -1,8 +1,6 @@
 name: Timeout
 
 on:
-  pull_request:
-    branches: [ master ]
   workflow_dispatch:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ For details of the `workflow_dispatch` even see [this blog post introducing this
 
 ## Outputs
 
+### `workflow-id`
+
+> The ID of the worflow run that has been triggered.
+
 ### `workflow-url`
 
 > The URL of the workflow run that has been triggered. It may be undefined if the URL couldn't be retrieved (timeout reached) or if `wait-for-completion` and `display-workflow-run-url` are > both `false`
@@ -94,6 +98,36 @@ For details of the `workflow_dispatch` even see [this blog post introducing this
 
 > The result of the triggered workflow. May be one of `success`, `failure`, `cancelled`, `timed_out`, `skipped`, `neutral`, `action_required`. The step in your workflow will fail if the triggered workflow completes with `failure`, `cancelled` or `timed_out`. Other workflow conlusion are considered success.
 > Only available if `wait-for-completion` is `true`
+
+### `workflow-logs`
+
+> The logs of the triggered workflow based if `inputs.workflow-logs` is set to either `output`, or `json-output`.  
+> Based on the value, result will be:
+>
+> * `output`: Multiline string
+>
+>   ```log
+>   <job-name> | <datetime> <message>
+>   <job-name> | <datetime> <message>
+>   ...
+>   ```
+>
+> * `json-output`: JSON string
+>
+>   ```json
+>   {
+>     "<job-name>": [
+>       {
+>         "datetime": "<datetime>",
+>         "message": "<message>"
+>       },
+>       {
+>         "datetime": "<datetime>",
+>         "message": "<message>"
+>       }
+>     ]
+>   }
+>   ```
 
 ## Example usage
 
@@ -153,6 +187,32 @@ For details of the `workflow_dispatch` even see [this blog post introducing this
 - name: Another step that can handle the result
   if: always()
   run: echo "Another Workflow conclusion: ${{ steps.trigger-step.outputs.workflow-conclusion }}"
+```
+
+### Invoke workflow and scrap output
+
+```yaml
+- name: Invoke workflow and scrap output
+  id: trigger-step
+  uses: aurelien-baudet/workflow-dispatch@v2
+  with:
+    workflow: Another Workflow
+    token: ${{ secrets.PERSONAL_TOKEN }}
+    workflow-logs: json-output
+- name: Another step that can handle the result
+  if: always()
+  run: echo '${{ fromJSON(steps.trigger-step.outputs.workflow-logs).my-remote-job }}'
+```
+
+```yaml
+name: Another Workflow
+
+on:
+  workflow_dispatch:
+
+jobs:
+  my-remote-job:
+    - run: echo "Hello world!"
 ```
 
 ### Invoke workflow with a unique run name (since 3.0.0)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ For details of the `workflow_dispatch` even see [this blog post introducing this
 
 ### `token`
 
-> **Required.** A GitHub access token (PAT) with write access to the repo in question. 
+> **Required.** A GitHub access token (PAT) with write access to the repo in question.
 >
 > **NOTE.** The automatically provided token e.g. `${{ secrets.GITHUB_TOKEN }}` can not be used, GitHub prevents this token from being able to fire the  `workflow_dispatch` and `repository_dispatch` event. [The reasons are explained in the docs](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token).  
 > The solution is to manually create a PAT and store it as a secret e.g. `${{ secrets.PERSONAL_TOKEN }}`

--- a/README.md
+++ b/README.md
@@ -11,77 +11,94 @@ For details of the `workflow_dispatch` even see [this blog post introducing this
 
 *Note 2.* If you want to reference the target workflow by ID, you will need to list them with the following REST API call `curl https://api.github.com/repos/{{owner}}/{{repo}}/actions/workflows -H "Authorization: token {{pat-token}}"`
 
-_This action is a fork of `benc-uk/workflow-dispatch` to add support for waiting for workflow completion._
+*This action is a fork of `benc-uk/workflow-dispatch` to add support for waiting for workflow completion.*
 
 ## Inputs
+
 ### `workflow`
+
 > **Required.** The name or the filename or ID of the workflow to trigger and run.
 
 ### `token`
 
 > **Required.** A GitHub access token (PAT) with write access to the repo in question. 
-> 
+>
 > **NOTE.** The automatically provided token e.g. `${{ secrets.GITHUB_TOKEN }}` can not be used, GitHub prevents this token from being able to fire the  `workflow_dispatch` and `repository_dispatch` event. [The reasons are explained in the docs](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token).  
 > The solution is to manually create a PAT and store it as a secret e.g. `${{ secrets.PERSONAL_TOKEN }}`
 
 ### `inputs`
+
 > **Optional.** The inputs to pass to the workflow (if any are configured), this must be a JSON encoded string, e.g. `{ "myInput": "foobar" }`.
 >
 > All values must be strings (even if they are used as booleans or numbers in the triggered workflow). The triggered workflow should use `fromJson` function to get the right type
 
 ### `ref`
+
 > **Optional.** The Git reference used with the triggered workflow run. The reference can be a branch, tag, or a commit SHA. If omitted the context ref of the triggering workflow is used. If you want to trigger on pull requests and run the target workflow in the context of the pull request branch, set the ref to `${{ github.event.pull_request.head.ref }}`
 
 ### `repo`
+
 > **Optional.** The default behavior is to trigger workflows in the same repo as the triggering workflow, if you wish to trigger in another GitHub repo "externally", then provide the owner + repo name with slash between them e.g. `microsoft/vscode`
 
 ### `run-name` (since 3.0.0)
+
 > **Optional.** The default behavior is to get the remote run ID based on the latest workflow name and date, if you have multiple of the same workflow running at the same time it can point to an incorrect run id.
-> You can specify the run name to fetch the run ID based on the actual run name.
+> To prevent from this, you can specify a unique run name to fetch the concerned run ID. It will also requires you to set that same value as an input for your remote workflow (See the [corresponding example](#invoke-workflow-with-a-unique-run-name-since-300))
 
 ### `wait-for-completion`
+
 > **Optional.** If `true`, this action will actively poll the workflow run to get the result of the triggered workflow. It is enabled by default. If the triggered workflow fails due to either `failure`, `timed_out` or `cancelled` then the step that has triggered the other workflow will be marked as failed too.
 
 ### `wait-for-completion-timeout`
+
 > **Optional.** The time to wait to mark triggered workflow has timed out. The time must be suffixed by the time unit e.g. `10m`. Time unit can be `s` for seconds, `m` for minutes and `h` for hours. It has no effect if `wait-for-completion` is `false`. Default is `1h`
 
 ### `wait-for-completion-interval`
+
 > **Optional.** The time to wait between two polls for getting run status. The time must be suffixed by the time unit e.g. `10m`. Time unit can be `s` for seconds, `m` for minutes and `h` for hours. It has no effect if `wait-for-completion` is `false`. Default is `1m`.
-> 
+>
 > **/!\ Do not use a value that is too small to avoid `API Rate limit exceeded`**
 
 ### `display-workflow-run-url`
+
 > **Optional.** If `true`, it displays in logs the URL of the triggered workflow. It is useful to follow the progress of the triggered workflow. It is enabled by default.
 
 ### `display-workflow-run-url-timeout`
+
 > **Optional.** The time to wait for getting the workflow run URL. If the timeout is reached, it doesn't fail and continues. Displaying the workflow URL is just for information purpose. The time must be suffixed by the time unit e.g. `10m`. Time unit can be `s` for seconds, `m` for minutes and `h` for hours. It has no effect if `display-workflow-run-url` is `false`. Default is `10m`
 
 ### `display-workflow-run-url-interval`
+
 > **Optional.** The time to wait between two polls for getting workflow run URL. The time must be suffixed by the time unit e.g. `10m`. Time unit can be `s` for seconds, `m` for minutes and `h` for hours. It has no effect if `display-workflow-run-url` is `false`. Default is `1m`.
-> 
+>
 > **/!\ Do not use a value that is too small to avoid `API Rate limit exceeded`**
 
 ### `workflow-logs`
+
 > **Optional.** Indicate what to do with logs of the triggered workflow:
-> 
+>
 > * `print`: Retrieve the logs for each job of the triggered workflow and print into the logs of the job that triggered the workflow.
 > * `ignore`: Do not retrieve log of triggered workflow at all (default).
-> 
-> Only available when `wait-for-completion` is `true`. 
-> 
+>
+> Only available when `wait-for-completion` is `true`.
+>
 > Default is `ignore`.
 
-
 ## Outputs
+
 ### `workflow-url`
+
 > The URL of the workflow run that has been triggered. It may be undefined if the URL couldn't be retrieved (timeout reached) or if `wait-for-completion` and `display-workflow-run-url` are > both `false`
 
 ### `workflow-conclusion`
+
 > The result of the triggered workflow. May be one of `success`, `failure`, `cancelled`, `timed_out`, `skipped`, `neutral`, `action_required`. The step in your workflow will fail if the triggered workflow completes with `failure`, `cancelled` or `timed_out`. Other workflow conlusion are considered success.
 > Only available if `wait-for-completion` is `true`
 
-
 ## Example usage
+
+### Invoke workflow without inputs. Wait for result
+
 ```yaml
 - name: Invoke workflow without inputs. Wait for result
   uses: aurelien-baudet/workflow-dispatch@v2
@@ -89,6 +106,8 @@ _This action is a fork of `benc-uk/workflow-dispatch` to add support for waiting
     workflow: My Workflow
     token: ${{ secrets.PERSONAL_TOKEN }}
 ```
+
+### Invoke workflow without inputs. Don't wait for result
 
 ```yaml
 - name: Invoke workflow without inputs. Don't wait for result
@@ -99,6 +118,8 @@ _This action is a fork of `benc-uk/workflow-dispatch` to add support for waiting
     wait-for-completion: false
 ```
 
+### Invoke workflow with inputs
+
 ```yaml
 - name: Invoke workflow with inputs
   uses: aurelien-baudet/workflow-dispatch@v2
@@ -107,6 +128,8 @@ _This action is a fork of `benc-uk/workflow-dispatch` to add support for waiting
     token: ${{ secrets.PERSONAL_TOKEN }}
     inputs: '{ "message": "blah blah", "debug": true }'
 ```
+
+### Invoke workflow in another repo with inputs
 
 ```yaml
 - name: Invoke workflow in another repo with inputs
@@ -117,6 +140,8 @@ _This action is a fork of `benc-uk/workflow-dispatch` to add support for waiting
     token: ${{ secrets.PERSONAL_TOKEN }}
     inputs: '{ "message": "blah blah", "debug": true }'
 ```
+
+### Invoke workflow and handle result
 
 ```yaml
 - name: Invoke workflow and handle result
@@ -130,6 +155,38 @@ _This action is a fork of `benc-uk/workflow-dispatch` to add support for waiting
   run: echo "Another Workflow conclusion: ${{ steps.trigger-step.outputs.workflow-conclusion }}"
 ```
 
+### Invoke workflow with a unique run name (since 3.0.0)
+
+```yaml
+- name: Invoke workflow and handle result
+  id: trigger-step
+  uses: aurelien-baudet/workflow-dispatch@v3
+  env:
+    RUN_NAME: ${{ github.repository }}/actions/runs/${{ github.run_id }}
+  with:
+    run-name: ${{ env.RUN_NAME }}
+    workflow: Another Workflow
+    token: ${{ secrets.PERSONAL_TOKEN }}
+    inputs: >-
+      {
+        "run-name": "${{ env.RUN_NAME }}"
+      }
+```
+
+:warning: In you remote workflow, you will need to forward and use the `run-name` input (See [GitHub Action run-name](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#run-name))
+
+```yaml
+name: Another Workflow
+run-name: ${{ inputs.run-name }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      run-name:
+        description: 'The distinct run name used to retrieve the run ID. Defaults to the workflow name'
+        type: string
+        required: false
+```
 
 ## Contributions
 

--- a/action.yaml
+++ b/action.yaml
@@ -2,10 +2,10 @@ name: 'Workflow Dispatch and wait'
 description: 'Trigger and chain GitHub Actions workflows with workflow_dispatch events and wait for result'
 
 inputs:
-  workflow: 
+  workflow:
     description: 'Name or ID of workflow to run'
     required: true
-  token: 
+  token:
     description: 'GitHub token with repo write access, can NOT use secrets.GITHUB_TOKEN, see readme'
     required: true
   inputs:
@@ -37,7 +37,7 @@ inputs:
     required: false
     default: true
   wait-for-completion-timeout:
-    description: 'Maximum amount of time (+unit) to wait to mark workflow as timed out' 
+    description: 'Maximum amount of time (+unit) to wait to mark workflow as timed out'
     required: false
     default: 1h
   wait-for-completion-interval:
@@ -45,9 +45,27 @@ inputs:
     required: false
     default: 1m
   workflow-logs:
-    description: 'Indicate what to do with logs of the triggered workflow. `ignore` do not retrieve logs from tiggered workflow. `print` retrieves logs from triggered workflow and print in the workflow that triggered the other workflow.'
+    description: >-
+      Indicate what to do with logs of the triggered workflow.
+      `ignore` do not retrieve logs from tiggered workflow.
+      `print` retrieves logs from triggered workflow and print in the workflow that triggered the other workflow.
+      `output` retrieves logs from triggered workflow and set them as `workflow-logs` output.
+      `json-output` retrieves logs from triggered workflow and return a json array groupped by job name.
     required: false
     default: ignore
+
+outputs:
+  workflow-conclusion:
+    description: 'Conclusion of the triggered workflow'
+  workflow-id:
+    description: 'ID of the triggered workflow'
+  workflow-url:
+    description: 'URL of the triggered workflow'
+  workflow-logs:
+    description: |
+      Logs of the triggered workflow. Based on `inputs.workflow-logs`, format is set to:
+        - `output`: Multiline logs formatted as: '<job-name> | <datetime> <message>'
+        - `json-output`: JSON logs formatted as: '{"<job-name>": [{"<datetime>": "<message>"}]'
 
 runs:
   using: 'node16'

--- a/dist/index.js
+++ b/dist/index.js
@@ -9864,7 +9864,7 @@ function parse(inputsJson) {
             return JSON.parse(inputsJson);
         }
         catch (e) {
-            throw new Error(`Failed to parse 'inputs' parameter. Muse be a valid JSON.\nCause: ${e}`);
+            throw new Error(`Failed to parse 'inputs' parameter. Must be a valid JSON.\nCause: ${e}`);
         }
     }
     return {};

--- a/src/main.ts
+++ b/src/main.ts
@@ -66,7 +66,7 @@ async function handleLogs(args: any, workflowHandler: WorkflowHandler) {
     const workflowRunId = await workflowHandler.getWorkflowRunId()
     await handleWorkflowLogsPerJob(args, workflowRunId);
   } catch(e: any) {
-    core.error(`Failed to handle logs of tirggered workflow. Cause: ${e}`);
+    core.error(`Failed to handle logs of triggered workflow. Cause: ${e}`);
   }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -97,6 +97,7 @@ async function run(): Promise<void> {
 
     await handleLogs(args, workflowHandler);
 
+    core.setOutput('workflow-id', result?.id);
     core.setOutput('workflow-url', result?.url);
     computeConclusion(start, args.waitForCompletionTimeout, result);
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -22,7 +22,7 @@ function parse(inputsJson: string) {
     try {
       return JSON.parse(inputsJson);
     } catch(e) {
-      throw new Error(`Failed to parse 'inputs' parameter. Muse be a valid JSON.\nCause: ${e}`)
+      throw new Error(`Failed to parse 'inputs' parameter. Must be a valid JSON.\nCause: ${e}`)
     }
   }
   return {}

--- a/src/workflow-handler.ts
+++ b/src/workflow-handler.ts
@@ -36,6 +36,7 @@ const ofConclusion = (conclusion: string | null): WorkflowRunConclusion => {
 }
 
 export interface WorkflowRunResult {
+  id: number,
   url: string,
   status: WorkflowRunStatus,
   conclusion: WorkflowRunConclusion
@@ -87,6 +88,7 @@ export class WorkflowHandler {
       debug('Workflow Run status', response);
 
       return {
+        id: runId,
         url: response.data.html_url,
         status: ofStatus(response.data.status),
         conclusion: ofConclusion(response.data.conclusion)
@@ -110,6 +112,7 @@ export class WorkflowHandler {
       debug('Workflow Run artifacts', response);
 
       return {
+        id: runId,
         url: response.data.html_url,
         status: ofStatus(response.data.status),
         conclusion: ofConclusion(response.data.conclusion)

--- a/src/workflow-handler.ts
+++ b/src/workflow-handler.ts
@@ -134,7 +134,6 @@ export class WorkflowHandler {
         repo: this.repo,
         workflow_id: workflowId,
         event: 'workflow_dispatch',
-        branch: this.ref,
         created: `>=${new Date(this.triggerDate).toISOString()}`
       });
 


### PR DESCRIPTION
**Issue:**
As discussed [here](https://github.com/aurelien-baudet/workflow-dispatch/pull/15/files#r1437778117), I figured out that the current function `octokit.rest.checks.listForRef`, which is based on [`repos/OWNER/REPO/commits/REF/check-runs`](https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28#list-check-runs-for-a-git-reference), and used to retrieve the run id, when a run-name is provided, is not working.

Cause is that `check_name` is filled by Github with the [jobs.<job_id>](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_id) (or [jobs.<job_id>.name](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idname)) and not the [run-name](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#run-name) we are expecting.

**Solution:**
The default [`octokit.rest.actions.listWorkflowRuns`](https://octokit.github.io/rest.js/v20#actions-list-workflow-runs) currently used is also the proper one to filter based on the name.
So once we use the method, we only need to do an extra filter on the `name` attribute to match the proper `run-name`.
To limit the number of results, `created` parameter has also been set on the API call.

Since the two recent functions `findWorkflowRunIdFromFirstRunOfSameWorkflowId` and `findWorklowRunIdFromRunName` are merged back into `getWorkflowRunId`, I cleaned them.

**Extra changes:**
- Add `workflow-id` as output
- Add 2 new modes for `workflow-logs`:
  - `output`: Set remote workflow logs (as raw) in `workflow-logs` output
    ```text
    <job-name> | yyyy-MM-ddTHH:mm:ss.SSSSSSSZ <message>
    <job-name> | yyyy-MM-ddTHH:mm:ss.SSSSSSSZ <message>
    ```
  - `json-output`: Set remote workflow logs (as json object) in `workflow-logs` output
    ```json
    {
      "<job-name>": [
        {
          "datetime": "yyyy-MM-ddTHH:mm:ss.SSSSSSSZ",
          "message": "<message>"
        },
        {
          "datetime": "yyyy-MM-ddTHH:mm:ss.SSSSSSSZ",
          "message": "<message>"
        }
      ]
    }
    ```
- README.md
  - Do some lint
  - Add an extra example (with corresponding remote workflow) when using `run-name`
- action.yaml
  - Add `outputs` definition
- Fix some typos (`shoud`, `tirggered`, `Muse`)